### PR TITLE
Show CV and 中文简历 links side-by-side

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -17,7 +17,7 @@ redirect_from:
   <div class="hp-photo-col">
     <img class="hp-photo" src="{{ base_path }}/images/profile.webp" alt="Yihan Wang">
     <p class="hp-links">
-      <span lang="en"><a href="{{ base_path }}/files/resume.pdf">CV</a></span><span lang="zh"><a href="{{ base_path }}/files/resume_zh.pdf">简历</a></span> /
+      <a href="{{ base_path }}/files/resume.pdf">CV</a> / <a href="{{ base_path }}/files/resume_zh.pdf">中文简历</a> /
       <a href="{{ site.author.googlescholar }}">Google Scholar</a> /
       <a href="https://github.com/hanhan572">GitHub</a> /
       <a href="mailto:yihan.wang@dukekunshan.edu.cn">Email</a> /


### PR DESCRIPTION
## Summary
- Replace the `lang`-toggled CV span with two always-visible links: `CV / 中文简历`
- Matches the pattern on juntang1129.github.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)